### PR TITLE
Amend node-fetch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "dependencies": {
     "fetch-cookie": ">=0.7.3",
-    "node-fetch": ">=2.6.0"
+    "node-fetch": "^2.6.0"
   }
 }


### PR DESCRIPTION
The version of node-fetch as instructed currently in the package.json is `>=2.6.0` which for new installations is using v3 of node-fetch.

v3 of node fetch is an ESM module which is currently incompatible with Homebridge. See

https://www.reddit.com/r/homebridge/comments/q7z3tc/i_want_to_move_my_hoobs_to_homebridgevm/

Using `^2.6.0` as the version instead will continue to install v2 of node-fetch which is what is needed for the plugin to work.

Until this is changed and a new version of the plugin is published, anyone installing or updating the plugin will receive this error.